### PR TITLE
Fix build on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:16-alpine
 # installs development toolchain & libraries in order to build the sqlite package
 # on the ARM architecture 
 RUN apk add --no-cache python3 py3-pip bash curl make gcc libc-dev g++
-# ARM sqlite build executes "python", not "python3"
-RUN ln -s /usr/bin/python3 /usr/bin/python
+# ARM sqlite build executes "python", not "python3", sometimes python does not exist
+RUN [ -e /usr/bin/python ] || ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /opt/ivis-remote
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:16-alpine
-RUN apk add --no-cache python3 py3-pip bash curl
+
+# installs development toolchain & libraries in order to build the sqlite package
+# on the ARM architecture 
+RUN apk add --no-cache python3 py3-pip bash curl make gcc libc-dev g++
+# ARM sqlite build executes "python", not "python3"
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 WORKDIR /opt/ivis-remote
 
 COPY package*.json ./

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,8 +3,8 @@ FROM node:16-alpine
 # installs development toolchain & libraries in order to build the sqlite package
 # on the ARM architecture 
 RUN apk add --no-cache python3 py3-pip bash curl make gcc libc-dev g++
-# ARM sqlite build executes "python", not "python3"
-RUN ln -s /usr/bin/python3 /usr/bin/python
+# ARM sqlite build executes "python", not "python3", sometimes python does not exist
+RUN [ -e /usr/bin/python ] || ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /opt/ivis-remote
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,11 @@
 FROM node:16-alpine
-RUN apk add --no-cache python3 py3-pip bash curl
+
+# installs development toolchain & libraries in order to build the sqlite package
+# on the ARM architecture 
+RUN apk add --no-cache python3 py3-pip bash curl make gcc libc-dev g++
+# ARM sqlite build executes "python", not "python3"
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
 WORKDIR /opt/ivis-remote
 
 COPY package*.json ./


### PR DESCRIPTION
The SQLite npm package must be built directly from sources on ARM. The Docker image may now be built.

Added dev tools + libraries for building from sources